### PR TITLE
Resolve glob patterns for android assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ embedded.mobileprovision
 examples/helloworld/build
 examples/helloworld/target
 examples/raqote-winit/target
+
+.idea/

--- a/apk/src/lib.rs
+++ b/apk/src/lib.rs
@@ -78,6 +78,9 @@ impl Apk {
     }
 
     pub fn add_asset(&mut self, asset: &Path) -> Result<()> {
+        // const OPTIONS: ZipFileOptions = ZipFileOptions::Aligned(4096);
+        const OPTIONS: ZipFileOptions = ZipFileOptions::Compressed;
+
         let file_name = asset
             .file_name()
             .context("Asset must have file_name component")?;
@@ -86,12 +89,10 @@ impl Apk {
         // TODO: Also check NDK AASSET_MODE_STREAMING vs AASSET_MODE_BUFFER
         if asset.is_dir() {
             tracing::info!("Embedding asset directory `{}`", asset.display());
-            self.zip
-                .add_directory(asset, &dest, ZipFileOptions::Aligned(4096))
+            self.zip.add_directory(asset, &dest, OPTIONS)
         } else {
             tracing::info!("Embedding asset file `{}`", asset.display());
-            self.zip
-                .add_file(asset, &dest, ZipFileOptions::Aligned(4096))
+            self.zip.add_file(asset, &dest, OPTIONS)
         }
         .with_context(|| format!("While zipping `{}`", asset.display()))?;
 

--- a/msix/src/lib.rs
+++ b/msix/src/lib.rs
@@ -73,8 +73,13 @@ impl Msix {
         self.zip.add_file(source, dest, opts)
     }
 
-    pub fn add_directory(&mut self, source: &Path, dest: &Path) -> Result<()> {
-        self.zip.add_directory(source, dest)
+    pub fn add_directory(
+        &mut self,
+        source: &Path,
+        dest: &Path,
+        opts: ZipFileOptions,
+    ) -> Result<()> {
+        self.zip.add_directory(source, dest, opts)
     }
 
     pub fn finish(mut self, signer: Option<Signer>) -> Result<()> {

--- a/xbuild/src/cargo/config.rs
+++ b/xbuild/src/cargo/config.rs
@@ -1,16 +1,49 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Deserialize;
-use std::path::Path;
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    env::VarError,
+    ops::Deref,
+    path::{Path, PathBuf},
+};
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct Config {
     pub build: Option<Build>,
+    /// <https://doc.rust-lang.org/cargo/reference/config.html#env>
+    pub env: Option<BTreeMap<String, EnvOption>>,
 }
 
 impl Config {
     pub fn parse_from_toml(path: impl AsRef<Path>) -> Result<Self> {
         let contents = std::fs::read_to_string(path)?;
         Ok(toml::from_str(&contents)?)
+    }
+}
+
+#[derive(Debug)]
+pub struct LocalizedConfig {
+    pub config: Config,
+    /// The directory containing `./.cargo/config.toml`
+    pub workspace: PathBuf,
+}
+
+impl Deref for LocalizedConfig {
+    type Target = Config;
+
+    fn deref(&self) -> &Self::Target {
+        &self.config
+    }
+}
+
+impl LocalizedConfig {
+    pub fn new(workspace: PathBuf) -> Result<Self> {
+        Ok(Self {
+            config: Config::parse_from_toml(workspace.join(".cargo/config.toml"))?,
+            workspace,
+        })
     }
 
     /// Search for and open `.cargo/config.toml` in any parent of the workspace root path.
@@ -19,15 +52,217 @@ impl Config {
         let workspace = dunce::canonicalize(workspace)?;
         workspace
             .ancestors()
-            .map(|dir| dir.join(".cargo/config.toml"))
-            .find(|p| p.is_file())
-            .map(Config::parse_from_toml)
+            .find(|dir| dir.join(".cargo/config.toml").is_file())
+            .map(|p| p.to_path_buf())
+            .map(Self::new)
             .transpose()
+    }
+
+    /// Propagate environment variables from this `.cargo/config.toml` to the process environment
+    /// using [`std::env::set_var()`].
+    ///
+    /// Note that this is automatically performed when calling [`Subcommand::new()`][super::Subcommand::new()].
+    pub fn set_env_vars(&self) -> Result<()> {
+        if let Some(env) = &self.config.env {
+            for (key, env_option) in env {
+                // Existing environment variables always have precedence unless
+                // the extended format is used to set `force = true`:
+                if !matches!(env_option, EnvOption::Value { force: true, .. })
+                    && std::env::var_os(key).is_some()
+                {
+                    continue;
+                }
+
+                std::env::set_var(key, env_option.resolve_value(&self.workspace)?.as_ref())
+            }
+        }
+
+        Ok(())
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct Build {
-    #[serde(rename = "target-dir")]
     pub target_dir: Option<String>,
+}
+
+/// Serializable environment variable in cargo config, configurable as per
+/// <https://doc.rust-lang.org/cargo/reference/config.html#env>,
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum EnvOption {
+    String(String),
+    Value {
+        value: String,
+        #[serde(default)]
+        force: bool,
+        #[serde(default)]
+        relative: bool,
+    },
+}
+
+impl EnvOption {
+    /// Retrieve the value and canonicalize it relative to `config_parent` when [`EnvOption::Value::relative`] is set.
+    ///
+    /// `config_parent` is the directory containing `.cargo/config.toml` where this was parsed from.
+    pub fn resolve_value(&self, config_parent: impl AsRef<Path>) -> Result<Cow<'_, str>> {
+        Ok(match self {
+            Self::Value {
+                value,
+                relative: true,
+                force: _,
+            } => {
+                let value = config_parent.as_ref().join(value);
+                let value = dunce::canonicalize(&value)
+                    .with_context(|| format!("Failed to canonicalize `{}`", value.display()))?;
+                value
+                    .into_os_string()
+                    .into_string()
+                    .map_err(VarError::NotUnicode)?
+                    .into()
+            }
+            Self::String(value) | Self::Value { value, .. } => value.into(),
+        })
+    }
+}
+
+#[test]
+fn test_env_parsing() {
+    let toml = r#"
+[env]
+# Set ENV_VAR_NAME=value for any process run by Cargo
+ENV_VAR_NAME = "value"
+# Set even if already present in environment
+ENV_VAR_NAME_2 = { value = "value", force = true }
+# Value is relative to .cargo directory containing `config.toml`, make absolute
+ENV_VAR_NAME_3 = { value = "relative/path", relative = true }"#;
+
+    let mut env = BTreeMap::new();
+    env.insert(
+        "ENV_VAR_NAME".to_string(),
+        EnvOption::String("value".into()),
+    );
+    env.insert(
+        "ENV_VAR_NAME_2".to_string(),
+        EnvOption::Value {
+            value: "value".into(),
+            force: true,
+            relative: false,
+        },
+    );
+    env.insert(
+        "ENV_VAR_NAME_3".to_string(),
+        EnvOption::Value {
+            value: "relative/path".into(),
+            force: false,
+            relative: true,
+        },
+    );
+
+    assert_eq!(
+        toml::from_str::<Config>(toml),
+        Ok(Config {
+            build: None,
+            env: Some(env)
+        })
+    );
+}
+
+#[test]
+fn test_env_precedence_rules() {
+    let toml = r#"
+[env]
+CARGO_SUBCOMMAND_TEST_ENV_NOT_FORCED = "not forced"
+CARGO_SUBCOMMAND_TEST_ENV_FORCED = { value = "forced", force = true }"#;
+
+    let config = LocalizedConfig {
+        config: toml::from_str::<Config>(toml).unwrap(),
+        workspace: PathBuf::new(),
+    };
+
+    // Check if all values are propagated to the environment
+    config.set_env_vars().unwrap();
+
+    assert!(matches!(
+        std::env::var("CARGO_SUBCOMMAND_TEST_ENV_NOT_SET"),
+        Err(VarError::NotPresent)
+    ));
+    assert_eq!(
+        std::env::var("CARGO_SUBCOMMAND_TEST_ENV_NOT_FORCED").unwrap(),
+        "not forced"
+    );
+    assert_eq!(
+        std::env::var("CARGO_SUBCOMMAND_TEST_ENV_FORCED").unwrap(),
+        "forced"
+    );
+
+    // Set some environment values
+    std::env::set_var(
+        "CARGO_SUBCOMMAND_TEST_ENV_NOT_FORCED",
+        "not forced process environment value",
+    );
+    std::env::set_var(
+        "CARGO_SUBCOMMAND_TEST_ENV_FORCED",
+        "forced process environment value",
+    );
+
+    config.set_env_vars().unwrap();
+
+    assert_eq!(
+        std::env::var("CARGO_SUBCOMMAND_TEST_ENV_NOT_FORCED").unwrap(),
+        // Value remains what is set in the process environment,
+        // and is not overwritten by set_env_vars()
+        "not forced process environment value"
+    );
+    assert_eq!(
+        std::env::var("CARGO_SUBCOMMAND_TEST_ENV_FORCED").unwrap(),
+        // Value is overwritten thanks to force=true, despite
+        // also being set in the process environment
+        "forced"
+    );
+}
+
+#[test]
+fn test_env_canonicalization() {
+    use std::ffi::OsStr;
+
+    let toml = r#"
+[env]
+CARGO_SUBCOMMAND_TEST_ENV_SRC_DIR = { value = "src", force = true, relative = true }
+"#;
+
+    let config = LocalizedConfig {
+        config: toml::from_str::<Config>(toml).unwrap(),
+        workspace: PathBuf::new(),
+    };
+
+    config.set_env_vars().unwrap();
+
+    let path = std::env::var("CARGO_SUBCOMMAND_TEST_ENV_SRC_DIR")
+        .expect("Canonicalization for a known-to-exist ./src folder should not fail");
+    let path = PathBuf::from(path);
+    assert!(path.is_absolute());
+    assert!(path.is_dir());
+    assert_eq!(path.file_name(), Some(OsStr::new("src")));
+
+    let toml = r#"
+[env]
+CARGO_SUBCOMMAND_TEST_ENV_INEXISTENT_DIR = { value = "blahblahthisfolderdoesntexist", force = true, relative = true }
+"#;
+
+    let config = LocalizedConfig {
+        config: toml::from_str::<Config>(toml).unwrap(),
+        workspace: PathBuf::new(),
+    };
+
+    let e = config.set_env_vars().unwrap_err();
+
+    assert_eq!(
+        e.to_string(),
+        "Failed to canonicalize `blahblahthisfolderdoesntexist`"
+    );
+    assert_eq!(
+        e.root_cause().to_string(),
+        "No such file or directory (os error 2)"
+    );
 }

--- a/xbuild/src/cargo/config.rs
+++ b/xbuild/src/cargo/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde::Deserialize;
 use std::{
     borrow::Cow,
@@ -111,16 +111,13 @@ impl EnvOption {
                 value,
                 relative: true,
                 force: _,
-            } => {
-                let value = config_parent.as_ref().join(value);
-                let value = dunce::canonicalize(&value)
-                    .with_context(|| format!("Failed to canonicalize `{}`", value.display()))?;
-                value
-                    .into_os_string()
-                    .into_string()
-                    .map_err(VarError::NotUnicode)?
-                    .into()
-            }
+            } => config_parent
+                .as_ref()
+                .join(value)
+                .into_os_string()
+                .into_string()
+                .map_err(VarError::NotUnicode)?
+                .into(),
             Self::String(value) | Self::Value { value, .. } => value.into(),
         })
     }

--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -10,7 +10,7 @@ mod utils;
 
 pub use artifact::{Artifact, CrateType};
 
-use self::config::Config;
+use self::config::LocalizedConfig;
 use self::manifest::Manifest;
 use crate::{CompileTarget, Opt};
 
@@ -74,11 +74,10 @@ impl Cargo {
 
         // TODO: Find, parse, and merge _all_ config files following the hierarchical structure:
         // https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
-        let config = Config::find_cargo_config_for_workspace(package_root)?;
-        // TODO: Import LocalizedConfig code from cargo-subcommand and propagate `[env]`
-        // if let Some(config) = &config {
-        //     config.set_env_vars().unwrap();
-        // }
+        let config = LocalizedConfig::find_cargo_config_for_workspace(package_root)?;
+        if let Some(config) = &config {
+            config.set_env_vars().unwrap();
+        }
 
         let target_dir = target_dir
             .or_else(|| {
@@ -101,7 +100,7 @@ impl Cargo {
                 .unwrap_or_else(|| &manifest_path)
                 .parent()
                 .unwrap()
-                .join(utils::get_target_dir_name(config.as_ref()).unwrap())
+                .join(utils::get_target_dir_name(config.as_deref()).unwrap())
         });
 
         Ok(Self {

--- a/xbuild/src/command/build.rs
+++ b/xbuild/src/command/build.rs
@@ -92,7 +92,11 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                             path,
                             optional: false,
                         } => {
-                            let paths = glob(path.as_os_str().to_str()?)?;
+                            let paths = glob(
+                                path.as_os_str()
+                                    .to_str()
+                                    .context("Failed to convert path to str")?,
+                            )?;
                             for path in paths {
                                 let path = env.cargo().package_root().join(path?);
                                 apk.add_asset(&path)?
@@ -102,7 +106,11 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                             path,
                             optional: true,
                         } => {
-                            let paths = glob(path.as_os_str().to_str()?)?;
+                            let paths = glob(
+                                path.as_os_str()
+                                    .to_str()
+                                    .context("Failed to convert path to str")?,
+                            )?;
                             for glob_result in paths {
                                 if let Ok(path) = glob_result {
                                     let path = env.cargo().package_root().join(path);

--- a/xbuild/src/config.rs
+++ b/xbuild/src/config.rs
@@ -312,6 +312,13 @@ impl Config {
     }
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum OptionalPath {
+    Path(PathBuf),
+    Optional { path: PathBuf, optional: bool },
+}
+
 #[derive(Deserialize)]
 struct RawConfig {
     #[serde(flatten)]
@@ -342,6 +349,8 @@ pub struct AndroidConfig {
     pub gradle: bool,
     #[serde(default)]
     pub wry: bool,
+    #[serde(default)]
+    pub assets: Vec<OptionalPath>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/xbuild/src/devices/adb.rs
+++ b/xbuild/src/devices/adb.rs
@@ -1,6 +1,6 @@
 use crate::devices::{Backend, Device};
 use crate::{Arch, Platform};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use apk::Apk;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -11,8 +11,44 @@ use std::time::Duration;
 pub(crate) struct Adb(PathBuf);
 
 impl Adb {
-    pub fn which() -> Result<Self> {
-        Ok(Self(which::which(exe!("adb"))?))
+    pub fn which() -> Result<PathBuf> {
+        const ADB: &str = exe!("adb");
+
+        match which::which(ADB) {
+            Err(which::Error::CannotFindBinaryPath) => {
+                let sdk_path = {
+                    let sdk_path = std::env::var("ANDROID_SDK_ROOT").ok();
+                    if sdk_path.is_some() {
+                        eprintln!(
+                            "Warning: Environment variable ANDROID_SDK_ROOT is deprecated \
+                    (https://developer.android.com/studio/command-line/variables#envar). \
+                    It will be used until it is unset and replaced by ANDROID_HOME."
+                        );
+                    }
+
+                    PathBuf::from(
+                        sdk_path
+                            .or_else(|| std::env::var("ANDROID_HOME").ok())
+                            .context(
+                            "Cannot find `adb` on in PATH nor is ANDROID_HOME/ANDROID_SDK_ROOT set",
+                        )?,
+                    )
+                };
+
+                let adb_path = sdk_path.join("platform-tools").join(ADB);
+                anyhow::ensure!(
+                    adb_path.exists(),
+                    "Expected `adb` at `{}`",
+                    adb_path.display()
+                );
+                Ok(adb_path)
+            }
+            r => r.context("Could not find `adb` in PATH"),
+        }
+    }
+
+    pub fn new() -> Result<Self> {
+        Ok(Self(Self::which()?))
     }
 
     fn adb(&self, device: &str) -> Command {

--- a/xbuild/src/devices/mod.rs
+++ b/xbuild/src/devices/mod.rs
@@ -5,9 +5,9 @@ use crate::{Arch, BuildEnv, Platform};
 use anyhow::Result;
 use std::path::Path;
 
-mod adb;
-mod host;
-mod imd;
+pub(crate) mod adb;
+pub(crate) mod host;
+pub(crate) mod imd;
 
 #[derive(Clone, Debug)]
 enum Backend {
@@ -31,7 +31,7 @@ impl std::str::FromStr for Device {
         }
         if let Some((backend, id)) = device.split_once(':') {
             let backend = match backend {
-                "adb" => Backend::Adb(Adb::which()?),
+                "adb" => Backend::Adb(Adb::new()?),
                 "imd" => Backend::Imd(IMobileDevice::which()?),
                 _ => anyhow::bail!("unsupported backend {}", backend),
             };
@@ -58,7 +58,7 @@ impl std::fmt::Display for Device {
 impl Device {
     pub fn list() -> Result<Vec<Self>> {
         let mut devices = vec![Self::host()];
-        if let Ok(adb) = Adb::which() {
+        if let Ok(adb) = Adb::new() {
             adb.devices(&mut devices)?;
         }
         if let Ok(imd) = IMobileDevice::which() {

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -387,7 +387,7 @@ pub struct BuildTargetArgs {
     /// Build artifacts for target device. To find the device
     /// identifier of a connected device run `x devices`.
     #[clap(long, conflicts_with = "store")]
-    device: Option<Device>,
+    device: Option<String>,
     /// Build artifacts with format. Can be one of `aab`,
     /// `apk`, `appbundle`, `appdir`, `appimage`, `dmg`,
     /// `exe`, `ipa`, `msix`.
@@ -424,6 +424,9 @@ impl BuildTargetArgs {
             Some(Device::host())
         } else {
             self.device
+                .as_ref()
+                .map(|device| device.parse())
+                .transpose()?
         };
         let platform = if let Some(platform) = self.platform {
             platform

--- a/xcommon/src/lib.rs
+++ b/xcommon/src/lib.rs
@@ -286,14 +286,20 @@ impl Zip {
     }
 
     pub fn add_file(&mut self, source: &Path, dest: &Path, opts: ZipFileOptions) -> Result<()> {
-        let mut f = File::open(source)?;
+        let mut f = File::open(source)
+            .with_context(|| format!("While opening file `{}`", source.display()))?;
         self.start_file(dest, opts)?;
         std::io::copy(&mut f, &mut self.zip)?;
         Ok(())
     }
 
-    pub fn add_directory(&mut self, source: &Path, dest: &Path) -> Result<()> {
-        add_recursive(self, source, dest)?;
+    pub fn add_directory(
+        &mut self,
+        source: &Path,
+        dest: &Path,
+        opts: ZipFileOptions,
+    ) -> Result<()> {
+        add_recursive(self, source, dest, opts)?;
         Ok(())
     }
 
@@ -335,17 +341,19 @@ impl Zip {
     }
 }
 
-fn add_recursive(zip: &mut Zip, source: &Path, dest: &Path) -> Result<()> {
-    for entry in std::fs::read_dir(source)? {
+fn add_recursive(zip: &mut Zip, source: &Path, dest: &Path, opts: ZipFileOptions) -> Result<()> {
+    for entry in std::fs::read_dir(source)
+        .with_context(|| format!("While reading directory `{}`", source.display()))?
+    {
         let entry = entry?;
         let file_name = entry.file_name();
         let source = source.join(&file_name);
         let dest = dest.join(&file_name);
         let file_type = entry.file_type()?;
         if file_type.is_dir() {
-            add_recursive(zip, &source, &dest)?;
+            add_recursive(zip, &source, &dest, opts)?;
         } else if file_type.is_file() {
-            zip.add_file(&source, &dest, ZipFileOptions::Compressed)?;
+            zip.add_file(&source, &dest, opts)?;
         }
     }
     Ok(())


### PR DESCRIPTION
Projects using bevy have an `assets` directory. It can contain files and more directories. I think this is a common pattern.

If I want to have the whole content of the `assets` directory inside the `apk` I cannot configure `"../assets"` as that will include the directory, not all the content (path will be `/assets/assets/...`). Without this PR, I need to add every subdirectory and every file in the `assets` directory to the manifest
```yaml
assets:
    - "../assets/audio"
    - "../assets/fonts"
    - "../assets/icon.png"
    - "../assets/config.toml"
```
That means every time I add a new file or folder, I need to modify the manifest.

With the glob support added by this PR it is just `"../assets/*"`.